### PR TITLE
[FEAT] : ⚙️ 좋아요  구현완료

### DIFF
--- a/app/src/main/java/bootcamp/sparta/myapplemarket/abstract/RecyclerViewItemInterface.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/abstract/RecyclerViewItemInterface.kt
@@ -1,0 +1,13 @@
+package bootcamp.sparta.myapplemarket.abstract
+
+import android.view.View
+
+// RecyclerViewItem에서 사용하는 ClickEvent용 interface
+interface onRecyclerViewItemClickListener {
+    fun onItemClick(view: View, position: Int)
+}
+
+// RecyclerViewItem에서 사용하는 LongClickEvent용 interface
+interface onRecyclerViewItemLongClickListener {
+    fun onItemLongClick(view: View, position: Int)
+}

--- a/app/src/main/java/bootcamp/sparta/myapplemarket/data/ProductsItemData.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/data/ProductsItemData.kt
@@ -1,0 +1,10 @@
+package bootcamp.sparta.myapplemarket.data
+
+import bootcamp.sparta.myapplemarket.data.model.Product
+
+object ProductsItemData {
+    private val productsList : MutableList<Product> = getDummyData()
+
+    fun getProducts() = productsList
+    fun getProducts(id: Int) = productsList.find { it.id == id }
+}

--- a/app/src/main/java/bootcamp/sparta/myapplemarket/data/model/Product.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/data/model/Product.kt
@@ -15,4 +15,5 @@ data class Product(
     val price: String, // 가격
     val chat: String, // 채팅개수
     val like: Int, // 좋아요 수
+    val isLike: Boolean // 좋아요 클릭여부
 ) : Parcelable

--- a/app/src/main/java/bootcamp/sparta/myapplemarket/data/model/Product.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/data/model/Product.kt
@@ -1,6 +1,7 @@
 package bootcamp.sparta.myapplemarket.data.model
 
 import android.os.Parcelable
+import bootcamp.sparta.myapplemarket.R
 import kotlinx.parcelize.Parcelize
 
 // 제품 Model Class
@@ -14,6 +15,7 @@ data class Product(
     val location: String, // 지역
     val price: String, // 가격
     val chat: String, // 채팅개수
+    var likeIcon: Int = R.drawable.icon_like, // 좋아요 아이콘
     var like: Int, // 좋아요 수
     var isLike: Boolean = false // 좋아요 클릭여부
 ) : Parcelable

--- a/app/src/main/java/bootcamp/sparta/myapplemarket/data/model/Product.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/data/model/Product.kt
@@ -14,6 +14,6 @@ data class Product(
     val location: String, // 지역
     val price: String, // 가격
     val chat: String, // 채팅개수
-    val like: Int, // 좋아요 수
-    val isLike: Boolean // 좋아요 클릭여부
+    var like: Int, // 좋아요 수
+    var isLike: Boolean = false // 좋아요 클릭여부
 ) : Parcelable

--- a/app/src/main/java/bootcamp/sparta/myapplemarket/detail/DetailPageActivity.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/detail/DetailPageActivity.kt
@@ -12,24 +12,26 @@ import androidx.appcompat.widget.Toolbar
 import android.R.*
 import bootcamp.sparta.myapplemarket.R
 import bootcamp.sparta.myapplemarket.abstract.BasePageActivity
+import bootcamp.sparta.myapplemarket.data.ProductsItemData
 import bootcamp.sparta.myapplemarket.data.model.Product
 import bootcamp.sparta.myapplemarket.databinding.DetailPageActivityBinding
+import bootcamp.sparta.myapplemarket.main.MainPageActivity
 import bootcamp.sparta.myapplemarket.util.setComma
 
 class DetailPageActivity : BasePageActivity() {
     private lateinit var binding: DetailPageActivityBinding
 
-    private lateinit var toolbar : Toolbar // 뒤로가기
-    private lateinit var ivImage : ImageView // 상단 제품이미지
-    private lateinit var ivProfileCircle : ImageView // 프로필사진
-    private lateinit var tvUserId : TextView // 사용자명
-    private lateinit var tvLocation : TextView // 위치
-    private lateinit var tvPrice : TextView // 위치
-    private lateinit var ivMannerIcon: ImageView // 메너 아이콘
-    private lateinit var tvMannerTemperature : TextView // 메너온도
-    private lateinit var tvBoardTitle : TextView // 글 제목
-    private lateinit var tvBoardContents : TextView // 글 내용
-    private lateinit var likeButton : ImageButton // 좋아요버튼
+    private lateinit var toolbar: Toolbar // 뒤로가기
+    private lateinit var ivImage: ImageView // 상단 제품이미지
+    private lateinit var tvUserId: TextView // 사용자명
+    private lateinit var tvLocation: TextView // 위치
+    private lateinit var tvPrice: TextView // 위치
+    private lateinit var tvBoardTitle: TextView // 글 제목
+    private lateinit var tvBoardContents: TextView // 글 내용
+    private lateinit var likeButton: ImageButton // 좋아요버튼
+
+    private var position: Int = 0
+
     companion object {
         fun newIntnet(context: Context): Intent = Intent(context, DetailPageActivity::class.java)
     }
@@ -47,12 +49,9 @@ class DetailPageActivity : BasePageActivity() {
     override fun initView() {
         toolbar = binding.detailToolbar
         ivImage = binding.detailImage
-//        ivProfileCircle = binding.detailProfileCircle
         tvUserId = binding.detailUserid
         tvLocation = binding.detailUserLocation
         tvPrice = binding.detailTvPrice
-//        ivMannerIcon = binding.detailIconManner
-//        tvMannerTemperature = binding.detailTvTemperature
         tvBoardTitle = binding.detailBoardTitle
         tvBoardContents = binding.detailBoardContent
         likeButton = binding.detailLike
@@ -62,16 +61,19 @@ class DetailPageActivity : BasePageActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.let {
             it.setDisplayHomeAsUpEnabled(true)
-            it.title=""
+            it.title = ""
             it.setHomeAsUpIndicator(R.drawable.back_arrow)
         }
     }
 
     // 툴바 뒤로가기버튼처리
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when(item.itemId){
+        when (item.itemId) {
             id.home -> {
                 finish()
+                val intent: Intent = MainPageActivity.newIntent(this)
+                    .putExtra("intent_position", position)
+               startActivity(intent)
                 return true
             }
         }
@@ -79,7 +81,7 @@ class DetailPageActivity : BasePageActivity() {
     }
 
     private fun setViewValue() {
-        val item = getItemData()
+        val item = getIntentItemData()
         item?.let {
             ivImage.setImageResource(it.image)
             tvUserId.text = it.user
@@ -87,14 +89,46 @@ class DetailPageActivity : BasePageActivity() {
             tvPrice.text = setComma(it.price) + "원"
             tvBoardTitle.text = it.title
             tvBoardContents.text = it.description
+            likeButton.setImageResource(it.likeIcon)
+            setButtonOnClickListener(item.id)
+            position = item.id - 1
         }
     }
 
-    private fun getItemData() : Product? {
+    private fun getIntentItemData(): Product? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            return intent.getParcelableExtra(getString(R.string.intent_key_product), Product::class.java)
+            return intent.getParcelableExtra(
+                getString(R.string.intent_key_product),
+                Product::class.java
+            )
         } else {
             return intent.getParcelableExtra<Product>("intent_product")
         }
+    }
+
+    private fun setButtonOnClickListener(id: Int) {
+        likeButton.setOnClickListener {
+            val item = ProductsItemData.getProducts(id)
+            item?.let {
+                it.isLike = !it.isLike
+                if (it.isLike) {
+                    it.like += 1
+                    it.likeIcon = R.drawable.icon_like_fill
+                } else {
+                    it.like -= 1
+                    it.likeIcon = R.drawable.icon_like
+                }
+            }
+            refreshView(item!!)
+        }
+    }
+
+    private fun refreshView(item: Product) {
+        val intent: Intent = DetailPageActivity.newIntnet(this)
+        intent.putExtra("intent_product", item)
+        finish()
+        overridePendingTransition(0, 0)
+        startActivity(intent)
+        overridePendingTransition(0, 0)
     }
 }

--- a/app/src/main/java/bootcamp/sparta/myapplemarket/main/MainPageRecyclerViewAdapter.kt
+++ b/app/src/main/java/bootcamp/sparta/myapplemarket/main/MainPageRecyclerViewAdapter.kt
@@ -9,6 +9,8 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import bootcamp.sparta.myapplemarket.data.model.Product
 import bootcamp.sparta.myapplemarket.databinding.MainItemRecyclerviewBinding
+import bootcamp.sparta.myapplemarket.abstract.onRecyclerViewItemClickListener
+import bootcamp.sparta.myapplemarket.abstract.onRecyclerViewItemLongClickListener
 import bootcamp.sparta.myapplemarket.util.setComma
 
 
@@ -17,14 +19,6 @@ class MainPageRecyclerViewAdapter(
     val onItemClickEventListener: onRecyclerViewItemClickListener? = null,
     val onItemLongClickEventListener: onRecyclerViewItemLongClickListener? = null
 ) : RecyclerView.Adapter<MainPageRecyclerViewAdapter.Holder>() {
-
-    interface onRecyclerViewItemClickListener {
-        fun onItemClick(view: View, position: Int)
-    }
-
-    interface onRecyclerViewItemLongClickListener {
-        fun onItemLongClick(view: View, position: Int)
-    }
 
     private val mListData: MutableList<Product>
 
@@ -61,21 +55,30 @@ class MainPageRecyclerViewAdapter(
             price.text = setComma(data.price) + "원"
             chat.text = data.chat
             like.text = data.like.toString()
+            changeLikeIconDrawable(data.likeIcon)
+            setItemClickListener(itemView)
+        }
 
+        // 좋아요 아이콘 drawable 변경
+        private fun changeLikeIconDrawable(icon: Int) {
+            like.setCompoundDrawablesWithIntrinsicBounds(null, null, itemView.resources.getDrawable(icon, null), null)
+        }
+
+        private fun setItemClickListener(itemView: View) {
+            // item Click
             itemView.setOnClickListener(this)
+            // 좋아요 Click
+            like.setOnClickListener(this)
+            // item LongClick
             itemView.setOnLongClickListener(this)
         }
 
         override fun onClick(p0: View?) {
-            onItemClick?.let{
-                it.onItemClick(p0!!, layoutPosition)
-            }
+            onItemClick?.onItemClick(p0!!, layoutPosition)
         }
 
         override fun onLongClick(p0: View?): Boolean {
-            onItemLongClick?.let {
-                it.onItemLongClick(p0!!, layoutPosition)
-            }
+            onItemLongClick?.onItemLongClick(p0!!, layoutPosition)
             return false
         }
     }

--- a/app/src/main/res/drawable/icon_like_fill.xml
+++ b/app/src/main/res/drawable/icon_like_fill.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:drawable="@drawable/baseline_favorite_fill_24"
-        android:width="10dp"
-        android:height="10dp"
+        android:width="17dp"
+        android:height="17dp"
         />
 </layer-list>

--- a/app/src/main/res/layout/main_item_recyclerview.xml
+++ b/app/src/main/res/layout/main_item_recyclerview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/item_main_layout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"


### PR DESCRIPTION
# MainPageActivity와 DetailPageActivity의 좋아요 동기화처리 구현하였습니다.
- Main과 Detail 양쪽에서 사용할 Product형 List 생성
- Main과 RecyclerViewAdapter가 통신할 interface정의(onRecyclerViewItemClickListener, onRecyclerViewItemLongClickListener)
- Main의 좋아요버튼 클릭시 ProductList에 데이터 적용 및 화면 새로고침 구현
- Detail의 좋아요버튼 클릭시 ProductList에 데이터 적용 및 화면 새록고침 구현
- Detail에서 뒤로가기 클릭시 현재 DetailPage의 item position값을 intent로 Main에 넘기도록 구현
- Detail -> Main 이동후 Main에 해당 position의 item 화면 새로고침 구현
- 좋아요 아이콘크기 17dp로 조정
- Product 모델클레스에 icon Drawable 저장용 매개변수 추가